### PR TITLE
Removed failing webpage blog kubernetes-operators-best-practices

### DIFF
--- a/src/main/java/org/acme/ArticleIngestor.java
+++ b/src/main/java/org/acme/ArticleIngestor.java
@@ -48,7 +48,9 @@ public class ArticleIngestor {
       throws UnsupportedEncodingException, IOException, URISyntaxException {
 
     List<String> articleURLs=findAllArticles();    
-
+ 
+    articleURLs.remove("https://www.redhat.com/en/blog/kubernetes-operators-best-practices");
+    
     System.out.println(articleURLs.toString());
     System.out.println(articleURLs.size());
 


### PR DESCRIPTION
The web page https://www.redhat.com/en/blog/kubernetes-operators-best-practices is failing due to a redirect loop and is now removed from the articles' list.